### PR TITLE
adding db view for neighborhood specific summary

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -16,3 +16,4 @@ psql -U $NOLA311_DB_USER -d $NOLA311_DB_NAME -h $NOLA311_DB_HOST -p $NOLA311_DB_
 psql -U $NOLA311_DB_USER -d $NOLA311_DB_NAME -h $NOLA311_DB_HOST -p $NOLA311_DB_PORT -f views/closed_tickets_stats.sql -q
 psql -U $NOLA311_DB_USER -d $NOLA311_DB_NAME -h $NOLA311_DB_HOST -p $NOLA311_DB_PORT -f views/call_records_for_review.sql -q
 psql -U $NOLA311_DB_USER -d $NOLA311_DB_NAME -h $NOLA311_DB_HOST -p $NOLA311_DB_PORT -f views/call_records_with_call_for_details.sql -q
+psql -U $NOLA311_DB_USER -d $NOLA311_DB_NAME -h $NOLA311_DB_HOST -p $NOLA311_DB_PORT -f views/open_tickets_neighborhood_summary.sql -q

--- a/views/open_tickets_neighborhood_summary.sql
+++ b/views/open_tickets_neighborhood_summary.sql
@@ -1,0 +1,37 @@
+set search_path to 'nola311';
+
+drop view if exists nola311.open_tickets_neighborhood_summary;
+create view nola311.open_tickets_neighborhood_summary as (
+  with
+  open_tickets as (
+    select
+      neighborhood_district,
+      issue_type,
+      extract(year from ticket_created_date_time) as year_created,
+      extract(month from ticket_created_date_time) as month_created,
+      justify_interval(age(ticket_created_date_time)) as time_open
+    from nola311.calls
+    where ticket_status = 'Open'
+  ),
+  ticket_stats as (
+    select
+      neighborhood_district,
+      issue_type,
+      year_created,
+      month_created,
+      count(*) as number_open
+    from open_tickets
+    group by neighborhood_district, issue_type, year_created, month_created
+  )
+  select
+    issue_type,
+    neighborhood_district,
+    count(*) as num_issues
+  from ticket_stats
+  group by neighborhood_district, issue_type
+);
+
+comment on view nola311.open_tickets_neighborhood_summary is 'A summary of the total number of open tickets by issue type for each neighborhood';
+
+grant all on nola311.open_tickets_neighborhood_summary to nola311;
+


### PR DESCRIPTION
Related to #12 

Adding this view enables a simple query for the number of open issues in each neighborhood.

```
nola311=> select * from nola311.open_tickets_neighborhood_summary where neighborhood_district = 'BROADMOOR' order by num_issues desc;
             issue_type              | neighborhood_district | num_issues
-------------------------------------+-----------------------+------------
 Pothole/Roadway Surface Repair      | BROADMOOR             |         47
 Street Flooding/Drainage            | BROADMOOR             |         24
 Catch Basin Maintenance             | BROADMOOR             |         19
 Sidewalk Repair                     | BROADMOOR             |         18
 Traffic Sign                        | BROADMOOR             |         14
 Tree Service                        | BROADMOOR             |         12
 Subsidence                          | BROADMOOR             |         12
 Traffic Signal                      | BROADMOOR             |          7
 Street Light                        | BROADMOOR             |          6
 Abandoned Vehicle Reporting/Removal | BROADMOOR             |          6
 Manhole Cover Maintenance           | BROADMOOR             |          6
 Road Shoulder Repair                | BROADMOOR             |          4
 Road Surface Marking                | BROADMOOR             |          3
 Residential Recycling Programs      | BROADMOOR             |          2
 Illegal Dumping Reporting           | BROADMOOR             |          2
 Trash/Garbage Pickup                | BROADMOOR             |          1
 Large Item Trash/Garbage Pickup     | BROADMOOR             |          1
(17 rows)
```