### PR TITLE
Attempt to use Docker Hub-supported env vars to version image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 311 app
 
-[![](https://images.microbadger.com/badges/image/codefornola/311.svg)](https://microbadger.com/images/codefornola/311 "Get your own image badge on microbadger.com")[![](https://images.microbadger.com/badges/version/codefornola/311.svg)](https://microbadger.com/images/codefornola/311 "Get your own version badge on microbadger.com")
+**Docker Image** [![](https://images.microbadger.com/badges/image/codefornola/311.svg)](https://microbadger.com/images/codefornola/311 "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/codefornola/311.svg)](https://microbadger.com/images/codefornola/311 "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/commit/codefornola/311.svg)](https://microbadger.com/images/codefornola/311 "Get your own commit badge on microbadger.com")
 
 We want to build something better than the default Socrata 311 site:
 http://311explorer.nola.gov/main/category/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,11 @@
 FROM node
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/codefornola/311.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.schema-version="1.0.0-rc1" \
+      org.codeforneworleans.app-name="311 Explorer"
 WORKDIR /usr/src/app
 COPY package.json .
 RUN npm install

--- a/app/hooks/build
+++ b/app/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+docker build  --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $IMAGE_NAME .


### PR DESCRIPTION
References:

- https://docs.docker.com/docker-cloud/builds/advanced/
- https://medium.com/microscaling-systems/labelling-automated-builds-on-docker-hub-f3d073fb8e1
- https://github.com/rossf7/label-schema-automated-build/blob/master/Dockerfile
- https://github.com/rossf7/label-schema-automated-build/blob/master/hooks/build

Tested and validated that it's working:
- Docker Hub build: https://hub.docker.com/r/codefornola/311/builds/bibbrcv4g7xhthhzjuc9mfm/
- MicroBadges tags visible (select branch under "Versions"): https://microbadger.com/images/codefornola/311